### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2025-02-06
+
 ### Changed
 
 - Change the in-circuit decryption to use `component_sub_point` [#4]
 - Update `dusk-jubjub` dependency to version `0.15`
 - Update `dusk-plonk` dependency to version `0.21`
 
-[0.1.0]
+## [0.1.0] - 2024-11-25
 
 ### Added
 
@@ -24,5 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1]: https://github.com/dusk-network/jubjub-elgamal/issues/1
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/jubjub-elgamal/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/dusk-network/jubjub-elgamal/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/dusk-network/jubjub-elgamal/releases/tag/v0.2.0
 [0.1.0]: https://github.com/dusk-network/jubjub-elgamal/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Change the in-circuit decryption to use `component_sub_point` [#4]
+- Update `dusk-jubjub` dependency to version `0.15`
+- Update `dusk-plonk` dependency to version `0.21`
 
 [0.1.0]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jubjub-elgamal"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 repository = "https://github.com/dusk-network/jubjub-elgamal"
 description = "ElGamal encryption scheme implemented on the JubJub curve with support for zero-knowledge circuits"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ license = "MPL-2.0"
 exclude = [".github/workflows/dusk-ci.yml", ".gitignore"]
 
 [dependencies]
-dusk-jubjub = { version = "0.14", default-features = false, features = ["zeroize"] }
-dusk-plonk = { version = "0.20", default-features = false, features = ["alloc"], optional = true }
+dusk-jubjub = { version = "0.15", default-features = false, features = ["zeroize"] }
+dusk-plonk = { version = "0.21", default-features = false, features = ["alloc"], optional = true }
 
 [dev-dependencies]
 ff = { version = "0.13", default-features = false }


### PR DESCRIPTION
## [0.2.0] - 2025-02-06

### Changed

- Change the in-circuit decryption to use `component_sub_point` [#4]
- Update `dusk-jubjub` dependency to version `0.15`
- Update `dusk-plonk` dependency to version `0.21`

[0.2.0]: https://github.com/dusk-network/jubjub-elgamal/releases/tag/v0.2.0