### PR TITLE
Bump to v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2025-02-25
+
 ### Added
 
 - Add encryption methods for u64 values [#9]
@@ -40,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1]: https://github.com/dusk-network/jubjub-elgamal/issues/1
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/jubjub-elgamal/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/dusk-network/jubjub-elgamal/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/dusk-network/jubjub-elgamal/releases/tag/v0.3.0
 [0.2.0]: https://github.com/dusk-network/jubjub-elgamal/releases/tag/v0.2.0
 [0.1.0]: https://github.com/dusk-network/jubjub-elgamal/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jubjub-elgamal"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 repository = "https://github.com/dusk-network/jubjub-elgamal"
 description = "ElGamal encryption scheme implemented on the JubJub curve with support for zero-knowledge circuits"


### PR DESCRIPTION
## [0.3.0] - 2025-02-25

### Added

- Add encryption methods for u64 values [#9]

### Changed

- Change methods to return shared_key and allow decryption from it [#7]
- Change encryption gadget to include bad encryption check [#8]
- Change encryption methods to allow custom generators [#11]

[0.3.0]: https://github.com/dusk-network/jubjub-elgamal/releases/tag/v0.3.0