### PR TITLE
Bump to v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.4.1] - 2025-03-12
+## [0.4.2] - 2025-03-12
 
 ### Added
 
@@ -58,8 +58,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1]: https://github.com/dusk-network/jubjub-elgamal/issues/1
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/jubjub-elgamal/compare/v0.4.1...HEAD
-[0.4.1]: https://github.com/dusk-network/jubjub-elgamal/releases/tag/v0.4.1
+[Unreleased]: https://github.com/dusk-network/jubjub-elgamal/compare/v0.4.2...HEAD
+[0.4.2]: https://github.com/dusk-network/jubjub-elgamal/releases/tag/v0.4.2
 [0.4.0]: https://github.com/dusk-network/jubjub-elgamal/releases/tag/v0.4.0
 [0.3.0]: https://github.com/dusk-network/jubjub-elgamal/releases/tag/v0.3.0
 [0.2.0]: https://github.com/dusk-network/jubjub-elgamal/releases/tag/v0.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jubjub-elgamal"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 repository = "https://github.com/dusk-network/jubjub-elgamal"
 description = "ElGamal encryption scheme implemented on the JubJub curve with support for zero-knowledge circuits"


### PR DESCRIPTION
## [0.4.2] - 2025-03-12

### Added

- Added Rkyv derivation for Encryption struct

[0.4.2]: https://github.com/dusk-network/jubjub-elgamal/releases/tag/v0.4.2