### PR TITLE
Adapt ZK gadgets to torsion-free witness points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Adapt ZK gadgets to Plonk's torsion-free witness point API [#28]
+
 ## [0.5.0] - 2026-02-27
 
 ### Added
@@ -63,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add initial implementation [#1]
 
 <!-- ISSUES -->
+[#28]: https://github.com/dusk-network/jubjub-elgamal/issues/28
 [#25]: https://github.com/dusk-network/jubjub-elgamal/issues/25
 [#9]: https://github.com/dusk-network/jubjub-elgamal/issues/9
 [#11]: https://github.com/dusk-network/jubjub-elgamal/issues/11

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.85"
 dusk-jubjub = { version = "0.15", default-features = false, features = [
   "zeroize",
 ] }
-dusk-plonk = { version = "0.22.0-rc.0", default-features = false, features = [
+dusk-plonk = { git = "https://github.com/dusk-network/plonk.git", rev = "b5519818c0dc6ed94847b6789d4ec3035ffa7f7e", default-features = false, features = [
   "alloc",
 ], optional = true }
 rkyv = { version = "0.7", optional = true, default-features = false }

--- a/src/zk.rs
+++ b/src/zk.rs
@@ -9,26 +9,33 @@ use dusk_bytes::Serializable;
 use dusk_jubjub::GENERATOR;
 use dusk_plonk::prelude::*;
 
+// Point arguments use `TorsionFreeWitnessPoint` so callers must establish
+// subgroup membership at the circuit boundary before invoking these gadgets.
+
 /// Enumeration used to decrypt ciphertexts in-circuit
 pub enum DecryptFrom {
     /// From a secret key
     SecretKey(Witness),
     /// From a shared key
-    SharedKey(WitnessPoint),
+    SharedKey(TorsionFreeWitnessPoint),
 }
 
-/// `ElGamal` encryption of a [`JubJubExtended`] plaintext
-/// in a Witness form, meant to be used in-circuit
+/// `ElGamal` encryption of a [`JubJubExtended`] plaintext in a
+/// subgroup-qualified witness form, meant to be used in-circuit.
 #[derive(Debug)]
 pub struct Encryption {
-    pub(crate) ciphertext_1: WitnessPoint,
-    pub(crate) ciphertext_2: WitnessPoint,
+    pub(crate) ciphertext_1: TorsionFreeWitnessPoint,
+    pub(crate) ciphertext_2: TorsionFreeWitnessPoint,
 }
 
 impl Encryption {
-    /// Creates a new [`Encryption`] from two Witness points
+    /// Creates a new [`Encryption`] from two subgroup-qualified witness
+    /// points.
     #[must_use]
-    pub fn new(ciphertext_1: WitnessPoint, ciphertext_2: WitnessPoint) -> Self {
+    pub fn new(
+        ciphertext_1: TorsionFreeWitnessPoint,
+        ciphertext_2: TorsionFreeWitnessPoint,
+    ) -> Self {
         Self {
             ciphertext_1,
             ciphertext_2,
@@ -38,19 +45,19 @@ impl Encryption {
     /// Returns the `ciphertext_1` point of the [`Encryption`] in a Witness
     /// form.
     #[must_use]
-    pub fn c1(&self) -> &WitnessPoint {
+    pub fn c1(&self) -> &TorsionFreeWitnessPoint {
         &self.ciphertext_1
     }
 
     /// Returns the `ciphertext_2` point of the [`Encryption`] in a Witness
     /// form.
     #[must_use]
-    pub fn c2(&self) -> &WitnessPoint {
+    pub fn c2(&self) -> &TorsionFreeWitnessPoint {
         &self.ciphertext_2
     }
 
     /// Uses the given `public_key` and a fresh random number `r` to encrypt a
-    /// plaintext [`WitnessPoint`] in a gadget that can be used in a
+    /// plaintext [`TorsionFreeWitnessPoint`] in a gadget that can be used in a
     /// plonk-circuit.
     ///
     /// ## Return
@@ -62,11 +69,11 @@ impl Encryption {
     /// be decrypted.
     pub fn encrypt(
         composer: &mut Composer,
-        public_key: WitnessPoint,
-        plaintext: WitnessPoint,
-        generator: Option<WitnessPoint>,
+        public_key: TorsionFreeWitnessPoint,
+        plaintext: TorsionFreeWitnessPoint,
+        generator: Option<TorsionFreeWitnessPoint>,
         r: Witness,
-    ) -> Result<(Self, WitnessPoint), Error> {
+    ) -> Result<(Self, TorsionFreeWitnessPoint), Error> {
         let ciphertext_1 = match generator {
             Some(generator) => composer.component_mul_point(r, generator),
             _ => composer.component_mul_generator(r, GENERATOR)?,
@@ -77,7 +84,7 @@ impl Encryption {
 
         // we check if the original message can be recovered
         let dec = composer.component_sub_point(ciphertext_2, shared_key);
-        composer.assert_equal_point(dec, plaintext);
+        composer.assert_equal_point(dec.into(), plaintext.into());
 
         Ok((
             Self {
@@ -105,11 +112,11 @@ impl Encryption {
     /// be decrypted.
     pub fn encrypt_u64(
         composer: &mut Composer,
-        public_key: WitnessPoint,
+        public_key: TorsionFreeWitnessPoint,
         plaintext: Witness,
-        generator: Option<WitnessPoint>,
+        generator: Option<TorsionFreeWitnessPoint>,
         r: Witness,
-    ) -> Result<(Self, WitnessPoint), Error> {
+    ) -> Result<(Self, TorsionFreeWitnessPoint), Error> {
         // we take the u64 plaintext from the Witness
         let plaintext_le_u64 =
             &composer.index(plaintext).to_bytes()[..u64::SIZE];
@@ -117,8 +124,10 @@ impl Encryption {
             u64::from_le_bytes(plaintext_le_u64.try_into().unwrap());
 
         // we map the plaintext to a point on the curve
+        let mapped_plaintext = composer
+            .append_point(JubJubExtended::map_to_point(&plaintext_u64))?;
         let mapped_plaintext =
-            composer.append_point(JubJubExtended::map_to_point(&plaintext_u64));
+            composer.assert_torsion_free_point(mapped_plaintext);
 
         // we take the 64-bit representation of the Witness u64 plaintext
         // as an array of Witnesses
@@ -149,13 +158,13 @@ impl Encryption {
     /// original plaintext in a gadget that can be used in a plonk-circuit.
     ///
     /// ## Return
-    /// Returns the [`WitnessPoint`] plaintext.
+    /// Returns the [`TorsionFreeWitnessPoint`] plaintext.
     #[must_use]
     pub fn decrypt(
         &self,
         composer: &mut Composer,
         key: &DecryptFrom,
-    ) -> WitnessPoint {
+    ) -> TorsionFreeWitnessPoint {
         match key {
             DecryptFrom::SecretKey(secret_key) => {
                 let c1_sk = composer
@@ -219,16 +228,16 @@ impl Encryption {
 /// produces fewer gates, matching the circuit description from v0.2.0.
 ///
 /// # Return
-/// Returns the ciphertext tuple `(WitnessPoint, WitnessPoint)`.
+/// Returns the ciphertext tuple of [`TorsionFreeWitnessPoint`]s.
 ///
 /// # Errors
 /// This function will error if `r` is not a valid jubjub-scalar.
 pub fn encrypt_unchecked(
     composer: &mut Composer,
-    public_key: WitnessPoint,
-    plaintext: WitnessPoint,
+    public_key: TorsionFreeWitnessPoint,
+    plaintext: TorsionFreeWitnessPoint,
     r: Witness,
-) -> Result<(WitnessPoint, WitnessPoint), Error> {
+) -> Result<(TorsionFreeWitnessPoint, TorsionFreeWitnessPoint), Error> {
     let r_point = composer.component_mul_point(r, public_key);
     let ciphertext_1 = composer.component_mul_generator(r, GENERATOR)?;
     let ciphertext_2 = composer.component_add_point(plaintext, r_point);
@@ -243,14 +252,14 @@ pub fn encrypt_unchecked(
 /// the circuit description from v0.2.0.
 ///
 /// ## Return
-/// Returns the [`WitnessPoint`] plaintext.
+/// Returns the [`TorsionFreeWitnessPoint`] plaintext.
 #[must_use]
 pub fn decrypt_unchecked(
     composer: &mut Composer,
     secret_key: Witness,
-    ciphertext_1: WitnessPoint,
-    ciphertext_2: WitnessPoint,
-) -> WitnessPoint {
+    ciphertext_1: TorsionFreeWitnessPoint,
+    ciphertext_2: TorsionFreeWitnessPoint,
+) -> TorsionFreeWitnessPoint {
     let c1_sk = composer.component_mul_point(secret_key, ciphertext_1);
 
     // return plaintext

--- a/tests/encryption.rs
+++ b/tests/encryption.rs
@@ -97,6 +97,24 @@ mod zk {
     static LABEL: &[u8; 12] = b"dusk-network";
     const CAPACITY: usize = 14; // capacity required for the setup
 
+    fn append_torsion_free(
+        composer: &mut Composer,
+        point: impl Into<JubJubExtended>,
+    ) -> Result<TorsionFreeWitnessPoint, Error> {
+        let point = composer.append_point(point)?;
+        Ok(composer.assert_torsion_free_point(point))
+    }
+
+    fn small_order_point() -> JubJubExtended {
+        let point = JubJubAffine::from_raw_unchecked(
+            BlsScalar::zero(),
+            -BlsScalar::one(),
+        );
+        assert!(bool::from(point.is_on_curve()));
+        assert!(!bool::from(JubJubExtended::from(point).is_torsion_free()));
+        point.into()
+    }
+
     #[derive(Default, Debug)]
     pub struct ElGamalCircuit<const MUST_PASS: bool> {
         public_key: JubJubAffine,
@@ -127,9 +145,9 @@ mod zk {
     impl<const MUST_PASS: bool> Circuit for ElGamalCircuit<MUST_PASS> {
         fn circuit(&self, composer: &mut Composer) -> Result<(), Error> {
             // import inputs
-            let public_key = composer.append_point(self.public_key);
+            let public_key = append_torsion_free(composer, self.public_key)?;
             let secret_key = composer.append_witness(self.secret_key);
-            let plaintext = composer.append_point(self.plaintext);
+            let plaintext = append_torsion_free(composer, self.plaintext)?;
             let r = composer.append_witness(self.r);
 
             // encrypt plaintext using the public key
@@ -141,30 +159,32 @@ mod zk {
             if MUST_PASS {
                 // assert that the ciphertext is as expected
                 composer.assert_equal_public_point(
-                    *ciphertext.c1(),
-                    self.expected_ciphertext.c1(),
-                );
+                    (*ciphertext.c1()).into(),
+                    *self.expected_ciphertext.c1(),
+                )?;
                 composer.assert_equal_public_point(
-                    *ciphertext.c2(),
-                    self.expected_ciphertext.c2(),
-                );
+                    (*ciphertext.c2()).into(),
+                    *self.expected_ciphertext.c2(),
+                )?;
 
                 // decrypt with sk
                 let dec_plaintext = ciphertext
                     .decrypt(composer, &DecryptFromZK::SecretKey(secret_key));
 
                 // assert decoded plaintext is the same as the original
-                composer.assert_equal_point(dec_plaintext, plaintext);
+                composer
+                    .assert_equal_point(dec_plaintext.into(), plaintext.into());
 
                 // decrypt with shared key
                 let dec_plaintext = ciphertext
                     .decrypt(composer, &DecryptFromZK::SharedKey(shared_key));
-                composer.assert_equal_point(dec_plaintext, plaintext);
+                composer
+                    .assert_equal_point(dec_plaintext.into(), plaintext.into());
 
                 // encrypt / decrypt plaintext using custom generator
-                let custom_gen = composer.append_point(
+                let custom_gen = composer.append_constant_point(
                     GENERATOR_EXTENDED * JubJubScalar::from(1234u64),
-                );
+                )?;
                 let custom_pk =
                     composer.component_mul_point(secret_key, custom_gen);
                 let (custom_enc, _) = EncryptionZK::encrypt(
@@ -177,7 +197,10 @@ mod zk {
 
                 let custom_dec_plaintext = custom_enc
                     .decrypt(composer, &DecryptFromZK::SecretKey(secret_key));
-                composer.assert_equal_point(custom_dec_plaintext, plaintext);
+                composer.assert_equal_point(
+                    custom_dec_plaintext.into(),
+                    plaintext.into(),
+                );
             }
 
             Ok(())
@@ -256,9 +279,9 @@ mod zk {
     impl Circuit for ElGamalInCircuitCheck {
         fn circuit(&self, composer: &mut Composer) -> Result<(), Error> {
             // import inputs
-            let public_key = composer.append_point(self.public_key);
+            let public_key = append_torsion_free(composer, self.public_key)?;
             let secret_key = composer.append_witness(self.secret_key);
-            let plaintext = composer.append_point(self.plaintext);
+            let plaintext = append_torsion_free(composer, self.plaintext)?;
             let r = composer.append_witness(self.r);
 
             // encrypt plaintext using the public-key
@@ -267,13 +290,13 @@ mod zk {
 
             // assert that the ciphertext is as expected
             composer.assert_equal_public_point(
-                ciphertext_1,
+                ciphertext_1.into(),
                 self.expected_ciphertext_1,
-            );
+            )?;
             composer.assert_equal_public_point(
-                ciphertext_2,
+                ciphertext_2.into(),
                 self.expected_ciphertext_2,
-            );
+            )?;
 
             // decrypt
             let dec_plaintext = zk::decrypt_unchecked(
@@ -284,7 +307,7 @@ mod zk {
             );
 
             // assert decoded plaintext is the same as the original
-            composer.assert_equal_point(dec_plaintext, plaintext);
+            composer.assert_equal_point(dec_plaintext.into(), plaintext.into());
 
             Ok(())
         }
@@ -327,24 +350,14 @@ mod zk {
     }
 
     #[test]
-    #[should_panic]
-    fn bad_encryption() {
+    fn checked_encryption_rejects_small_order_inputs() {
         let mut rng = StdRng::seed_from_u64(0xc0b);
 
         let sk = JubJubScalar::random(&mut rng);
-        let pk = GENERATOR_EXTENDED * sk;
-
-        // we set a message being a point not on the curve
-        let message =
-            JubJubExtended::from_affine(JubJubAffine::from_raw_unchecked(
-                BlsScalar::from(42),
-                BlsScalar::from(42),
-            ));
-
+        let public_key = GENERATOR_EXTENDED * sk;
+        let plaintext = GENERATOR_EXTENDED * JubJubScalar::from(1234u64);
+        let small_order = small_order_point();
         let r = JubJubScalar::random(&mut rng);
-
-        // not involved in this test
-        let ciphertext = Encryption::new(message, message).unwrap();
 
         let pp = PublicParameters::setup(1 << CAPACITY, &mut rng).unwrap();
 
@@ -352,18 +365,56 @@ mod zk {
             Compiler::compile::<ElGamalCircuit<false>>(&pp, LABEL)
                 .expect("failed to compile circuit");
 
-        // this should fail
-        let (_proof, _public_inputs) = prover
-            .prove(
-                &mut rng,
-                &ElGamalCircuit::<false>::new(
-                    &pk,
-                    &sk,
-                    &message,
-                    &r,
-                    &ciphertext,
-                ),
-            )
-            .expect("failed to prove");
+        for (public_key, plaintext) in
+            [(small_order, plaintext), (public_key, small_order)]
+        {
+            let circuit = ElGamalCircuit::<false>::new(
+                &public_key,
+                &sk,
+                &plaintext,
+                &r,
+                &Encryption::default(),
+            );
+            assert!(
+                prover.prove(&mut rng, &circuit).is_err(),
+                "small-order input should not prove"
+            );
+        }
+    }
+
+    #[test]
+    fn unchecked_encryption_rejects_small_order_inputs() {
+        let mut rng = StdRng::seed_from_u64(0xc0b);
+
+        let zero = JubJubScalar::zero();
+        let public_key = GENERATOR_EXTENDED;
+        let plaintext = GENERATOR_EXTENDED * JubJubScalar::from(1234u64);
+        let small_order = small_order_point();
+        let ciphertext_1 = GENERATOR_EXTENDED * zero;
+
+        let pp = PublicParameters::setup(1 << CAPACITY, &mut rng).unwrap();
+        let (prover, _verifier) =
+            Compiler::compile::<ElGamalInCircuitCheck>(&pp, LABEL)
+                .expect("failed to compile circuit");
+
+        // With a zero blinder and secret key, every other constraint is
+        // satisfied: c1 is the identity and c2 is the plaintext. Rejection is
+        // therefore attributable to the subgroup boundary checks.
+        for (public_key, plaintext) in
+            [(small_order, plaintext), (public_key, small_order)]
+        {
+            let circuit = ElGamalInCircuitCheck::new(
+                &public_key,
+                &zero,
+                &plaintext,
+                &zero,
+                &ciphertext_1,
+                &plaintext,
+            );
+            assert!(
+                prover.prove(&mut rng, &circuit).is_err(),
+                "small-order input should not prove"
+            );
+        }
     }
 }

--- a/tests/u64_encryption.rs
+++ b/tests/u64_encryption.rs
@@ -57,6 +57,14 @@ mod zk {
     static LABEL: &[u8; 12] = b"dusk-network";
     const CAPACITY: usize = 14; // capacity required for the setup
 
+    fn append_torsion_free(
+        composer: &mut Composer,
+        point: impl Into<JubJubExtended>,
+    ) -> Result<TorsionFreeWitnessPoint, Error> {
+        let point = composer.append_point(point)?;
+        Ok(composer.assert_torsion_free_point(point))
+    }
+
     #[derive(Default, Debug)]
     pub struct ElGamalCircuit {
         public_key: JubJubAffine,
@@ -87,7 +95,7 @@ mod zk {
     impl Circuit for ElGamalCircuit {
         fn circuit(&self, composer: &mut Composer) -> Result<(), Error> {
             // import inputs
-            let public_key = composer.append_point(self.public_key);
+            let public_key = append_torsion_free(composer, self.public_key)?;
             let secret_key = composer.append_witness(self.secret_key);
             let plaintext = composer.append_witness(self.plaintext);
             let r = composer.append_witness(self.r);
@@ -99,13 +107,13 @@ mod zk {
 
             // assert that the ciphertext is as expected
             composer.assert_equal_public_point(
-                *ciphertext.c1(),
-                self.expected_ciphertext.c1(),
-            );
+                (*ciphertext.c1()).into(),
+                *self.expected_ciphertext.c1(),
+            )?;
             composer.assert_equal_public_point(
-                *ciphertext.c2(),
-                self.expected_ciphertext.c2(),
-            );
+                (*ciphertext.c2()).into(),
+                *self.expected_ciphertext.c2(),
+            )?;
 
             // decrypt with sk
             let dec_plaintext = ciphertext
@@ -120,8 +128,9 @@ mod zk {
             composer.assert_equal(dec_plaintext, plaintext);
 
             // encrypt / decrypt plaintext using custom generator
-            let custom_gen = composer
-                .append_point(GENERATOR_EXTENDED * JubJubScalar::from(1234u64));
+            let custom_gen = composer.append_constant_point(
+                GENERATOR_EXTENDED * JubJubScalar::from(1234u64),
+            )?;
             let custom_pk =
                 composer.component_mul_point(secret_key, custom_gen);
             let (custom_enc, _) = EncryptionZK::encrypt_u64(


### PR DESCRIPTION
Resolves #28

Migrates the ElGamal ZK API to Plonk's typed subgroup boundary and covers checked, unchecked, and u64 proof paths plus small-order rejection.

The draft temporarily pins the current Plonk master revision. Replace it with the compatible crates.io release before marking this ready.

Validated with the full release proof suite and feature matrix on Rust 1.85.